### PR TITLE
fix: Refactor AgeKeygen to use CLIWrap and update dependencies

### DIFF
--- a/src/Devantler.AgeCLI/AgeKeygen.cs
+++ b/src/Devantler.AgeCLI/AgeKeygen.cs
@@ -57,10 +57,12 @@ public static class AgeKeygen
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    using var stdOut = Console.OpenStandardInput();
+    using var stdIn = Console.OpenStandardInput();
+    using var stdOut = Console.OpenStandardOutput();
     using var stdErr = Console.OpenStandardError();
     var command = Command.WithArguments(arguments)
       .WithValidation(validation)
+      .WithStandardInputPipe(silent ? PipeSource.Null : PipeSource.FromStream(stdIn))
       .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
       .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
     var result = await command.ExecuteBufferedAsync(cancellationToken);

--- a/src/Devantler.AgeCLI/AgeKeygen.cs
+++ b/src/Devantler.AgeCLI/AgeKeygen.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using CliWrap;
+using CliWrap.Buffered;
 using Devantler.CLIRunner;
 
 namespace Devantler.AgeCLI;
@@ -57,11 +58,13 @@ public static class AgeKeygen
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    return await CLI.RunAsync(
-      Command.WithArguments(arguments),
-      validation: validation,
-      silent: silent,
-      includeStdErr: includeStdErr,
-      cancellationToken: cancellationToken).ConfigureAwait(false);
+    using var stdOut = Console.OpenStandardInput();
+    using var stdErr = Console.OpenStandardError();
+    var command = Command.WithArguments(arguments)
+      .WithValidation(validation)
+      .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
+      .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
+    var result = await command.ExecuteBufferedAsync(cancellationToken);
+    return (result.ExitCode, result.StandardOutput + result.StandardError);
   }
 }

--- a/src/Devantler.AgeCLI/AgeKeygen.cs
+++ b/src/Devantler.AgeCLI/AgeKeygen.cs
@@ -1,7 +1,6 @@
 using System.Runtime.InteropServices;
 using CliWrap;
 using CliWrap.Buffered;
-using Devantler.CLIRunner;
 
 namespace Devantler.AgeCLI;
 

--- a/src/Devantler.AgeCLI/Devantler.AgeCLI.csproj
+++ b/src/Devantler.AgeCLI/Devantler.AgeCLI.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.CLIRunner" Version="1.0.36" />
+    <PackageReference Include="CLIWrap" Version="3.8.1" />
     <PackageReference Include="Devantler.Keys.Age" Version="1.0.18" />
   </ItemGroup>
 


### PR DESCRIPTION
Refactor the AgeKeygen implementation to utilize CLIWrap for command execution, enhancing performance and reliability. Update project dependencies to ensure compatibility and access to the latest features.